### PR TITLE
Disable auto{capitalize, complete, correct} in input field

### DIFF
--- a/explainshell/web/templates/index.html
+++ b/explainshell/web/templates/index.html
@@ -15,7 +15,7 @@
             <div class="text-center">
                 <div class="input-append">
                     <form id='form' method="get">
-                        <input class="span10" id="explain" type="text" name="args" autocapitalize="off" autocomplete="off"></input>
+                        <input class="span10" id="explain" type="text" name="args" autocapitalize="off" autocomplete="off" autocorrect="off"></input>
                         <button class="btn" type="submit">EXPLAIN</button>
                     </form>
                 </div>


### PR DESCRIPTION
This is particularly important since, e.g. "Rsync" is not recognized as "rsync". Also, the browser tries to autocorrect commands and flags, which is pretty much never what you want.
