### PR TITLE
README.md: set PYTHONPATH in manager.py example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To setup a working environment that lets you run the web interface locally, you'
 
 Use the manager to parse and save a gzipped man page in raw format:
 
-    $ python explainshell/manager.py --log info manpages/1/echo.1.gz
+    $ PYTHONPATH=. python explainshell/manager.py --log info manpages/1/echo.1.gz
     INFO:explainshell.store:creating store, db = 'explainshell_tests', host = 'mongodb://localhost'
     INFO:explainshell.algo.classifier:train on 994 instances
     INFO:explainshell.manager:handling manpage echo (from /tmp/es/manpages/1/echo.1.gz)


### PR DESCRIPTION
This avoids the following error:

    vagrant@precise64:/vagrant$ python explainshell/manager.py --log info manpages/1/echo.1.gz
    Traceback (most recent call last):
      File "explainshell/manager.py", line 3, in <module>
        from explainshell import options, store, fixer, manpage, errors, util, config
    ImportError: No module named explainshell
    vagrant@precise64:/vagrant$