### PR TITLE
vagrant: export LC_ALL=en_US.UTF-8 in .bashrc

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,6 +56,9 @@ Vagrant.configure("2") do |config|
     # http://redsymbol.net/articles/unofficial-bash-strict-mode/
     set -euo pipefail
 
+    # http://perlgeek.de/en/article/set-up-a-clean-utf8-environment
+    echo "export LC_ALL=en_US.UTF-8" >> ~vagrant/.bashrc
+
     sudo apt-get update
     sudo apt-get install -y python-pip mongodb make
 


### PR DESCRIPTION
Fixes https://github.com/idank/explainshell/issues/141

Note that `vagrant ssh -c` doesn't seem to run `.bashrc`:

    vagrant ssh -c "env | grep LC"
    LC_ALL=en_US
    Connection to 127.0.0.1 closed.

so you still need to run `vagrant ssh` to set `LC_ALL`:

    vagrant ssh
    Welcome to Ubuntu 12.04 LTS (GNU/Linux 3.2.0-23-generic x86_64)

     * Documentation:  https://help.ubuntu.com/
    New release '14.04.3 LTS' available.
    Run 'do-release-upgrade' to upgrade to it.

    Welcome to your Vagrant-built virtual machine.
    Last login: Mon Oct 26 16:43:01 2015 from 10.0.2.2
    vagrant@precise64:~$ env | grep LC
    LC_ALL=en_US.UTF-8