### PR TITLE
es.css/a: Tweak down S&L to 3:1 contrast

### DIFF
--- a/explainshell/web/static/css/es.css
+++ b/explainshell/web/static/css/es.css
@@ -7,7 +7,7 @@ body {
 }
 
 a {
-    color: #66a3ff;
+    color: #5795f3;
 }
 
 .program-text {


### PR DESCRIPTION
This PR partially fixes #38.

The original color, #66a3ff, has a contrast against white of 2.5:1 which is even smaller than WCAG 2.0 contrast on large text/icons (3:1). This commit decreases H to ~220 and L to ~165, and provides this value.

As a reference, H~225 and L~144 gives contrast = 3.9:1, close to the 4.5:1 recommended minimum. I'm not going that far, since a change so big means redrawing the site LOGO.