### PR TITLE
manager.py: set LC_ALL=en_US.UTF-8 to fix utf8 bug

### DIFF
--- a/explainshell/manpage.py
+++ b/explainshell/manpage.py
@@ -9,6 +9,7 @@ ENV = dict(os.environ)
 ENV["W3MMAN_MAN"] = "man --no-hyphenation"
 ENV["MAN_KEEP_FORMATTING"] = "1"
 ENV["MANWIDTH"] = "115"
+ENV["LC_ALL"] = "en_US.UTF-8"
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes https://github.com/idank/explainshell/issues/141 (see https://github.com/idank/explainshell/pull/142#issuecomment-151971632)
Closes https://github.com/idank/explainshell/issues/142