### PR TITLE
web/views: properly escape nested commands

### DIFF
--- a/explainshell/web/views.py
+++ b/explainshell/web/views.py
@@ -232,9 +232,14 @@ def formatmatch(d, m, expansions):
             s = m.match[relativestart:relativeend]
 
             if kind == 'substitution':
-                content = markupsafe.Markup('<a href="/explain?cmd={0}" '
-                                            'title="Zoom in to nested command">{0}'
-                                            '</a>').format(s)
+                content = markupsafe.Markup('<a href="/explain?{query}" '
+                                            'title="Zoom in to nested command">{cmd}'
+                                            '</a>').format({
+                                                'cmd': s,
+                                                'query': urllib.urlencode({
+                                                    'cmd': s,
+                                                }),
+                                            })
             else:
                 content = s
 


### PR DESCRIPTION
This fixes problems with e.g. `awk <&3`.