### PR TITLE
README.md: Fix header formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[explainshell.com](http://www.explainshell.com) - match command-line arguments to their help text
+## [explainshell.com](http://www.explainshell.com) - match command-line arguments to their help text
 
 explainshell is a tool (with a web interface) capable of parsing man pages, extracting options and
 explain a given command-line by matching each argument to the relevant help text in the man page.


### PR DESCRIPTION
The first line was presumably supposed to be a markdown header,
but was missing a space after the `#`.  Also, it renders a bit large to
as a level-1 header, so make it a level-2 header.