### PR TITLE
Fix defined(%hash)

### DIFF
--- a/tools/w3mman2html.cgi
+++ b/tools/w3mman2html.cgi
@@ -220,7 +220,7 @@ sub is_command {
   local($p);
 
   (! -d && -x) || return 0;
-  if (! defined(%PATH)) {
+  if (! (%PATH)) {
     for $p (split(":", $ENV{'PATH'})) {
       $p =~ s@/+$@@;
       $PATH{$p} = 1;


### PR DESCRIPTION
This fixes the error:

> Can't use 'defined(%hash)' (Maybe you should just omit the defined()?) at tools/w3mman2html.cgi line 223.