### PR TITLE
Add auto detection for dark browser/system mode

### DIFF
--- a/explainshell/web/static/js/es.js
+++ b/explainshell/web/static/js/es.js
@@ -1081,7 +1081,10 @@ function draw() {
 
 // Theme-related stuff
 $(document).ready(function() {
-    var selectedTheme = localStorage.getItem('theme') || 'default';
+    // use theme from local storage or auto-detect otherwise
+    var selectedTheme = localStorage.getItem('theme')
+        || (window.matchMedia("(prefers-color-scheme: dark)").matches ? 'dark' : 'default')
+        || 'default';
 
     function setTheme(theme) {
         console.log('setting theme to', theme);


### PR DESCRIPTION
via "prefers-color-scheme".

Fixes https://github.com/idank/explainshell/issues/236

(Only tested JS changes locally in browser.)

Testable with:
* Safari
* Firefox >=  67 (and [this add-on](https://addons.mozilla.org/firefox/addon/dark-mode-website-switcher/?src=external-github-issue) if wanted)