### PR TITLE
Change the example with the "useless use of echo" and backticks

### DIFF
--- a/explainshell/web/templates/index.html
+++ b/explainshell/web/templates/index.html
@@ -26,7 +26,7 @@
                     <ul>
                         {{ macros.examplebullet(":(){ :|:& };:") }}
                         {{ macros.examplebullet("for user in $(cut -f1 -d: /etc/passwd); do crontab -u $user -l 2>/dev/null; done") }}
-                        {{ macros.examplebullet('file=$(echo `basename "$file"`)') }}
+                        {{ macros.examplebullet('name=$(printf "%s@%s" "$(id -nu)" "$(uname -n)")') }}
                         {{ macros.examplebullet("true && { echo success; } || { echo failed; }") }}
                         {{ macros.examplebullet("cut -d ' ' -f 1 /var/log/apache2/access_logs | uniq -c | sort -n") }}
                         {{ macros.examplebullet('tar zcf - some-dir | ssh some-server "cd /; tar xvzf -"') }}


### PR DESCRIPTION
One of the examples on the front page,
```
file=$(echo `basename "$file"`)
```
is using the [deprecated][1] [backticks][2] and ["useless use of echo"][3]. As explainshell.com is likely to be used for learning shell, this potentially teaches those bad habits.

This PR changes the example to
```
name=$(printf "%s@%s" "$(id -nu)" "$(uname -n)")
```


[1]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03
[2]: https://unix.stackexchange.com/questions/126927/have-backticks-i-e-cmd-in-sh-shells-been-deprecated
[3]: https://porkmail.org/era/unix/award.html#echo