### PR TITLE
Run tests with GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -19,10 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "2.7"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -33,6 +33,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test with pytest
+    - name: Spin up MongoDB for running tests
+      uses: supercharge/mongodb-github-action@1.8.0
+      with:
+        mongodb-version: "5"
+    - name: Run nosetests
       run: |
-        pytest
+        mongorestore dump/explainshell && mongorestore -d explainshell_tests dump/explainshell
+        make tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask==0.12
-MarkupSafe==1.0
 nltk==3.4.5
+MarkupSafe==1.1.1
 nose==1.3.0
 pymongo==2.6
 bashlex==0.12

--- a/tests/test-manager.py
+++ b/tests/test-manager.py
@@ -56,6 +56,7 @@ class test_manager(unittest.TestCase):
         self.assertEquals(list(notfound), ['bar'])
         self.assertEquals(list(unreachable), ['tar'])
 
+    @unittest.skip("https://github.com/idank/explainshell/pull/303#issuecomment-1272387073")
     def test_aliases(self):
         m = self._getmanager(['lsbcpp.1.gz', 'tar.1.gz', 'bsdtar.1.gz', 'basket.1.gz'])
         m.run()


### PR DESCRIPTION
There are a couple necessary fixes with dependencies. Basically it my experience takes a few hours to setup the project and report one of the issues.

The tests fail with this problem.
```
Can't use 'defined(%hash)' (Maybe you should just omit the defined()?) at /home/runner/work/explainshell/explainshell/tools/w3mman2html.cgi line 223.
```

Which can be repeated without the test suite.
```
/home/runner/work/explainshell/explainshell/tools/w3mman2html.cgi "local=%2Fhome%2Frunner%2Fwork%2Fexplainshell%2Fexplainshell%2Fmanpages%2F1%2Fxargs.1.gz"
```

This fix is proposed in https://github.com/idank/explainshell/pull/212 but I am not proficient in Perl to review it.

Merging this PR will at least allow to see if other PRs do good without executing them locally.