### PR TITLE
fix(sec): upgrade nltk to 3.6.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.12
-nltk==3.4.5
+nltk==3.6.6
 MarkupSafe==1.1.1
 nose==1.3.0
 pymongo==2.6


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in nltk 3.4.5
- [MPS-2022-15003](https://www.oscs1024.com/hd/MPS-2022-15003)


### What did I do？
Upgrade nltk from 3.4.5 to 3.6.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS

Signed-off-by:pen4<948453219@qq.com>