### PR TITLE
pymongo: use projection=[] instead of fields={}

### DIFF
--- a/explainshell/store.py
+++ b/explainshell/store.py
@@ -356,7 +356,7 @@ class store(object):
         logger.info('updating manpage %s', m.source)
         m.updated = True
         self.manpage.update({'source' : m.source}, m.to_store())
-        _id = self.manpage.find_one({'source' : m.source}, fields={'_id':1})['_id']
+        _id = self.manpage.find_one({'source' : m.source}, projection=['_id'])['_id']
         for alias, score in m.aliases:
             if alias not in self:
                 self.addmapping(alias, _id, score)
@@ -369,7 +369,7 @@ class store(object):
         # check that everything in manpage is reachable
         mappings = list(self.mapping.find())
         reachable = set([m['dst'] for m in mappings])
-        manpages = set([m['_id'] for m in self.manpage.find(fields={'_id':1})])
+        manpages = set([m['_id'] for m in self.manpage.find(projection=['_id'])])
 
         ok = True
         unreachable = manpages - reachable
@@ -386,12 +386,12 @@ class store(object):
         return ok, unreachable, notfound
 
     def names(self):
-        cursor = self.manpage.find(fields={'name':1})
+        cursor = self.manpage.find(projection=['_id', 'name'])
         for d in cursor:
             yield d['_id'], d['name']
 
     def mappings(self):
-        cursor = self.mapping.find(fields={'src':1})
+        cursor = self.mapping.find(projection=['_id,', 'src'])
         for d in cursor:
             yield d['src'], d['_id']
 


### PR DESCRIPTION
With current pymongo==3.13.0, was causing exception:

```
> podman-compose exec web env PYTHONPATH=. python explainshell/manager.py --log info --verify
...
INFO:explainshell.store:creating store, db = 'explainshell', host = 'mongodb://db'
Traceback (most recent call last):
  File "explainshell/manager.py", line 201, in <module>
    sys.exit(main(args.files, args.db, args.host, args.overwrite, args.drop, args.verify))
  File "explainshell/manager.py", line 165, in main
    ok = s.verify()
  File "/opt/webapp/explainshell/store.py", line 372, in verify
    manpages = set([m['_id'] for m in self.manpage.find(fields={'_id':1})])
  File "/usr/local/lib/python2.7/site-packages/pymongo/collection.py", line 1696, in find
    return Cursor(self, *args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'fields'
exit code: 1
```
Now works:
```
> podman-compose exec web env PYTHONPATH=. python explainshell/manager.py --log info --verify
...
INFO:explainshell.store:creating store, db = 'explainshell', host = 'mongodb://db'
exit code: 0
```

I tested the other calls too; `updatemanpage` unreachable from
current CLI but tested same call in another code path.

Not sure when pymongo API changed; oldest doc I found online https://pymongo.readthedocs.io/en/3.5.1/api/pymongo/collection.html#pymongo.collection.Collection.find which doesn't mention `fields=` only `projection=`.  Probably broken since 8406b3189797a5b14059ce5dc8ffe2e12b4e9f28?

Change from {x: 1} to ['x'] style is cosmetic, reads less magic to me, but `projection` arg supports both.