### PR TITLE
fix IP port conflict on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ docker-compose exec -T web make tests
 Ran 80 tests in 0.041s
 
 OK (SKIP=9)
-# open http://localhost:5000 to view the ui
+# open http://localhost:5001 to view the ui
 ```
 
 ### Processing a man page

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,6 @@ services:
     volumes:
       - .:/opt/webapp
     ports:
-      - "5000:5000"
+      - "5001:5000"
     depends_on:
       - db


### PR DESCRIPTION
MacOS uses port 5000 for "Command Centre" (a buit-in application).

This change updates the explainshell/web container to be mapped to port 5001 on the host (i.e. localhost:5001 instead of localhost:5000).