### PR TITLE
Feature/debian fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:2.7
 
-RUN apt-get update \
+RUN sed -i 's|deb.debian.org/debian|archive.debian.org/debian|g' /etc/apt/sources.list \
+  && sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list \
+  && sed -i '/buster-updates/d' /etc/apt/sources.list \
+  && apt-get update \
   && apt-get install man-db -y \
   && apt-get clean
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   db:
     image: mongo


### PR DESCRIPTION
I have two small fixes.

1) Debian Buster distro (used in python:2.7 base docker image) is archived now. 
	So, `docker-compose build` fails with errors like `The repository "http://security.debian.org/debian-security buster/updates Release" does not have a Release file`.
	I changed Dockerfile to fix this.

2) `docker-compose.yml` contains `version` field, which is obsolete now and gives the warning when building. So it was removed.