### PR TITLE
fix(web): escape command substitution markup

### DIFF
--- a/explainshell/web/views.py
+++ b/explainshell/web/views.py
@@ -637,7 +637,7 @@ def _substitution_markup(cmd, explain_prefix="/explain"):
     >>> _substitution_markup('foo')
     '<a href="/explain?cmd=foo" title="Zoom in to nested command">foo</a>'
     >>> _substitution_markup('cat <&3')
-    '<a href="/explain?cmd=cat+%3C%263" title="Zoom in to nested command">cat <&3</a>'
+    '<a href="/explain?cmd=cat+%3C%263" title="Zoom in to nested command">cat &lt;&amp;3</a>'
     """
     encoded = urllib.parse.urlencode({"cmd": cmd})
-    return f'<a href="{explain_prefix}?{encoded}" title="Zoom in to nested command">{cmd}</a>'
+    return f'<a href="{explain_prefix}?{encoded}" title="Zoom in to nested command">{markupsafe.escape(cmd)}</a>'

--- a/tests/test_web_views.py
+++ b/tests/test_web_views.py
@@ -83,6 +83,15 @@ class TestExplainRouter(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertIn(b"bar", rv.data)
 
+    def test_command_substitution_escapes_nested_command(self):
+        rv = self.client.get(
+            "/explain",
+            query_string={"cmd": "withargs $(printf '<img src=x onerror=alert(1)>')"},
+        )
+        self.assertEqual(rv.status_code, 200)
+        self.assertNotIn(b"<img src=x onerror=alert(1)>", rv.data)
+        self.assertIn(b"&lt;img src=x onerror=alert(1)&gt;", rv.data)
+
     def test_explain_no_cmd_redirects(self):
         rv = self.client.get("/explain")
         self.assertEqual(rv.status_code, 302)


### PR DESCRIPTION
## Summary

- Escape the nested command shown inside command-substitution links.
- Add a route-level regression test for markup injected through a substitution body.

## Root cause

The link builder inserted command text into trusted HTML before the template rendered the match as safe markup.

## Checks

- Targeted store, matcher, and web tests: 179 passed.
- Web-view doctest: passed.
