### PR TITLE
fix(store): reconcile dotted and multiword mappings

### DIFF
--- a/explainshell/store.py
+++ b/explainshell/store.py
@@ -151,8 +151,10 @@ class Store:
     def find_man_page(
         self, name: str, distro: str | None = None, release: str | None = None
     ) -> list[ParsedManpage]:
-        """find a man page by its name, everything following the last dot (.) in name,
-        is taken as the section of the man page
+        """Find a man page by name.
+
+        An exact mapping takes precedence. When there is no exact mapping,
+        everything following the last dot (.) is taken as the man page section.
 
         we return the man page found with the highest score, and a list of
         suggestions that also matched the given name (only the first item
@@ -171,20 +173,25 @@ class Store:
             logger.debug("returning %s", m)
             return [m]
 
-        section = None
         orig_name = name
-
-        # don't try to look for a section if it's . (source)
-        if name != ".":
-            splitted = name.rsplit(".", 1)
-            name = splitted[0]
-            if len(splitted) > 1:
-                section = splitted[1]
-
         logger.debug("looking up manpage in mappings with src %r", name)
         mapping_rows = self._conn.execute(
             "SELECT dst, score FROM mappings WHERE src = ?", (name,)
         ).fetchall()
+
+        section = None
+        # Dotted command names (for example, ``systemd.exec``) are valid
+        # mapping keys. Only interpret a suffix as a section after the exact
+        # command lookup misses.
+        if not mapping_rows and name != ".":
+            name, separator, section = name.rpartition(".")
+            if separator:
+                logger.debug("looking up manpage in mappings with src %r", name)
+                mapping_rows = self._conn.execute(
+                    "SELECT dst, score FROM mappings WHERE src = ?", (name,)
+                ).fetchall()
+            else:
+                section = None
 
         if not mapping_rows:
             raise errors.ProgramDoesNotExist(name)
@@ -607,11 +614,16 @@ class Store:
                         parents[parent_name] = parent_source
 
         # Delete all existing subcommand mappings and re-insert the valid set
-        # in a single transaction.  Exclude alias mappings where src matches
-        # the manpage name (e.g. "pg_autoctl activate" whose name has a space).
+        # in a single transaction. Keep canonical mappings for multiword
+        # manpage names (e.g. "pg_autoctl activate") only when they point to
+        # that manpage itself.
         deleted = self._conn.execute(
             "DELETE FROM mappings WHERE src LIKE '% %' "
-            "AND src NOT IN (SELECT name FROM parsed_manpages WHERE name LIKE '% %')"
+            "AND NOT EXISTS ("
+            "SELECT 1 FROM parsed_manpages "
+            "WHERE parsed_manpages.source = mappings.dst "
+            "AND parsed_manpages.name = mappings.src"
+            ")"
         ).rowcount
 
         mappings_to_add = sorted(valid_mappings)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -86,6 +86,13 @@ class TestFindManpageScoring:
 
 
 class TestFindManpageSection:
+    def test_dotted_command_uses_exact_mapping_before_section(self, store):
+        mp = _make_manpage("systemd.exec", "5")
+        store.add_manpage(mp, _make_raw())
+
+        assert store.find_man_page("systemd.exec")[0].source == mp.source
+        assert store.find_man_page("systemd.exec.5")[0].source == mp.source
+
     def test_section_filter(self, store):
         """Specifying a section should return that section first."""
         mp1 = _make_manpage("printf", "1", aliases=[("printf", 10)])
@@ -549,6 +556,23 @@ class TestUpdateSubcommandMappingsLlm(_SubcommandTestBase):
         all_mappings = store.mappings()
         subcmd = [(s, d) for s, d in all_mappings if " " in s]
         assert len(subcmd) == len(set(subcmd))
+
+    def test_rerun_replaces_subcommand_mapping_with_multiword_name_collision(
+        self, store
+    ):
+        """A real multiword manpage must not preserve a stale subcommand row."""
+        store.add_manpage(
+            self._make_mp("foo", extractor="llm", subcommands=["bar"]),
+            _make_raw(),
+        )
+        child = self._make_mp("foo-bar", extractor="llm")
+        store.add_manpage(child, _make_raw())
+        store.add_manpage(self._make_mp("foo bar", extractor="llm"), _make_raw())
+
+        store.update_subcommand_mappings()
+        mappings_added, _ = store.update_subcommand_mappings()
+
+        assert mappings_added == [("foo bar", child.source)]
 
     def test_removes_stale_mappings(self, store):
         """Reconciliation removes subcommand mappings no longer declared by parent."""


### PR DESCRIPTION
## Summary

- Resolve dotted command names through their exact mapping before treating a suffix as a manpage section.
- Reconcile a stale subcommand mapping when its source collides with a real multiword manpage name.

## Root cause

Lookup stripped the last dotted component before querying mappings. Reconciliation preserved every mapping whose source matched any multiword name, including a subcommand row pointing to a different destination.

## Checks

- Targeted store, matcher, and web tests: 179 passed.
- Web-view doctest: passed.
