### PR TITLE
fix(matcher): recognize adjacent comments

### DIFF
--- a/explainshell/matcher.py
+++ b/explainshell/matcher.py
@@ -911,7 +911,7 @@ class Matcher(bashlex.ast.nodevisitor):
             # the parser ignores comments but we can use a trick to see if this
             # starts a comment and is beyond the ending index of the parsed
             # portion of the input
-            if (not self.ast or i > self.ast.pos[1]) and c == "#":
+            if (not self.ast or i >= self.ast.pos[1]) and c == "#":
                 comment = MatchResult(
                     i, len(parsed), help_constants.COMMENT, None, {"kind": "comment"}
                 )

--- a/tests/test_matcher.py
+++ b/tests/test_matcher.py
@@ -889,6 +889,19 @@ class test_matcher(unittest.TestCase):
         self.assertEqual(groups[0].results, shellresults)
         self.assertEqual(groups[1].results, matchresults)
 
+        cmd = "bar;#a comment"
+        shellresults = [
+            MR(3, 4, help_constants.OPSEMICOLON, ";"),
+            MR(4, 14, help_constants.COMMENT, "#a comment"),
+        ]
+        matchresults = [MR(0, 3, "bar synopsis", "bar")]
+
+        m = matcher.Matcher(cmd, s)
+        groups = m.match()
+        self.assertEqual(len(groups), 2)
+        self.assertEqual(groups[0].results, shellresults)
+        self.assertEqual(groups[1].results, matchresults)
+
         cmd = "# just a comment"
 
         shellresults = [MR(0, 16, help_constants.COMMENT, "# just a comment")]


### PR DESCRIPTION
## Summary

- Recognize a shell comment immediately after a command separator.
- Add a regression case for a semicolon followed directly by a comment marker.

## Root cause

The parser end offset is exclusive. The fallback comment detector required a character to occur after that offset, so a comment starting at the offset was rendered as an unknown token.

## Checks

- Targeted store, matcher, and web tests: 179 passed.
- Web-view doctest: passed.
